### PR TITLE
HC branch 1

### DIFF
--- a/bactabolize/alignment.py
+++ b/bactabolize/alignment.py
@@ -44,7 +44,10 @@ def run_blastp(query_fp, subject_fp):
     command_opts = f'-evalue 0.001 -outfmt \'6 {" ".join(BlastFormat)}\''
     command_run = f'blastp -db {subject_fp} -query {query_fp} {command_opts}'
     result = util.execute_command(command_run)
-    return parse_results(result.stdout)
+    if result.stdout != "":
+        return parse_results(result.stdout)
+    else:
+        return {}
 
 
 def run_blastn(query_fp, subject_fp):
@@ -54,7 +57,10 @@ def run_blastn(query_fp, subject_fp):
     command_opts = f'-evalue 0.001 -outfmt \'6 {" ".join(BlastFormat)}\''
     command_run = f'blastn -db {subject_fp} -query {query_fp} {command_opts}'
     result = util.execute_command(command_run)
-    return parse_results(result.stdout)
+    if result.stdout != "":
+        return parse_results(result.stdout)
+    else:
+        return {}
 
 
 def create_blast_database(subject_fp, db_type):

--- a/bactabolize/draft_model.py
+++ b/bactabolize/draft_model.py
@@ -138,7 +138,10 @@ def create_troubleshooter(model, model_draft, blast_results, biomass_reaction_id
             blastp_hits[(reaction, gene)] = hitsp
             if len(hitsp) > 0:
                 continue
-            blastn_hits[(reaction, gene)] = blast_results['blastn'].get(gene.id, list())
+            if len(blast_results['blastn']) != 0:
+                blastn_hits[(reaction, gene)] = blast_results['blastn'].get(gene.id, list())
+            else:
+                blastn_hits[(reaction, gene)] = []
     # Write summary info
     output_fp = pathlib.Path(f'{prefix}_summary.txt')
     write_troubleshoot_summary(
@@ -311,7 +314,10 @@ def identify(iso_fp, ref_genes_fp, ref_proteins_fp, model_genes, alignment_thres
             print(*[seq[i : i + 80] for i in range(0, len(seq), 80)], sep='\n', file=fout)
     # Run BLASTn (filtering with evalue <=1e-3, coverage >=80%, and pident >=80%)
     blastn_res_all = alignment.run_blastn(ref_genes_noorth_fp, iso_fasta_fp)
-    blastn_res = alignment.filter_results(blastn_res_all, min_coverage=80, min_pident=80)
+    if len(blastn_res_all) != 0:
+        blastn_res = alignment.filter_results(blastn_res_all, min_coverage=80, min_pident=80)
+    else:
+        blastn_res = {}
     # Discover unannotated model genes in isolate
     model_orthologs = discover_unannotated_orthologs(blastn_res, iso_fasta_fp, model_orthologs)
 

--- a/bactabolize/model_fba.py
+++ b/bactabolize/model_fba.py
@@ -28,6 +28,10 @@ def run(config):
     else:
         assert False
 
+    # Set all sink bounds to export only
+    for sink in model.sinks:
+        sink.lower_bound = 0
+
     # Run FBA
     results = dict()
     for fba_name, fba_spec in spec.items():


### PR DESCRIPTION
Changes made to Bactabolize to allow it to run iYL1228 and iKp1289 as reference models. 

1. Edits to `alignment.py` and `draft_model.py` meant that Bactabolize no longer terminate prematurely prior to model troubleshooting, which occurred when the blast output was empty (`AttributeError: 'BlastResult' object has no attribute 'qseqid'`). This error occurred when using single-strain metabolic models as some gene-protein-reaction rules didn't have all the main orthologs present in the population, and the gene present wasn't similar enough in other isolates to produce any form of blast hit (Eg: Reactions TDPDRR and TDPDRE in iYL1228). 

2. Edits to `model_fba.py` meant that prior to running the FBA analysis all sink reactions will be forced to only export metabolites, rather than having the ability to import substrates into the system. If sink reactions are allowed to remain reversible, this can cause the FBA growth predictions to be incorrect as they can import another C/N/P/S source separate to the one being tested. (Eg: sink__DASH__dna5mtc_c0 in iKp1289 allows for the importation and utilisation of carbon). 