### PR TITLE
Update annotate.py to fix a TypeError with annotations.py

### DIFF
--- a/conda/bactabolize/meta.yaml
+++ b/conda/bactabolize/meta.yaml
@@ -17,6 +17,13 @@ requirements:
   run:
     - python ==3.9
     - biopython ==1.79
+    - glpk ==5.0
+    - swiglpk ==5.0.10
+    - urllib3 ==2.2.2
+    - cchardet ==2.1.7
+    - tabulator ==1.25.1
+    - goodtables ==2.5.4
+    - openpyxl ==2.4.11
     - blast ==2.12.0
     - cobra ==0.21.0
     - prodigal ==2.6.3
@@ -28,7 +35,6 @@ requirements:
     - cookiecutter
     - depinfo ==1.7.0
     - gitpython
-    - goodtables ~=2.0
     - importlib_resources ==5.12.0
     - jinja2
     - numpydoc

--- a/requirements-dev.yaml
+++ b/requirements-dev.yaml
@@ -16,6 +16,13 @@ dependencies:
   - pylint >=2.5,<=2.14  # NOTE(SW): upper bound on version to avoid installing broken package
   # Dependencies
   - biopython ==1.79
+  - glpk ==5.0
+  - swiglpk ==5.0.10
+  - urllib3 ==2.2.2
+  - cchardet ==2.1.7
+  - tabulator ==1.25.1
+  - goodtables ==2.5.4
+  - openpyxl ==2.4.11
   - blast ==2.12.0
   - cobra ==0.21.0
   - prodigal ==2.6.3


### PR DESCRIPTION
Fixed error regarding unhashable SeqFeatures.

Error was as follows:

```bash
 warnings.warn(
Traceback (most recent call last):
  File "/projects/kr58/software/conda_envs/bactabolize_v1.0.1/bin/bactabolize", line 10, in <module>
    sys.exit(entry())
  File "/projects/kr58/software/conda_envs/bactabolize_v1.0.1/lib/python3.9/site-packages/bactabolize/main.py", line 23, in entry
    run_draft_model(config)
  File "/projects/kr58/software/conda_envs/bactabolize_v1.0.1/lib/python3.9/site-packages/bactabolize/main.py", line 49, in run_draft_model
    annotate.run(config.assembly_fp, config.assembly_genbank_fp)
  File "/projects/kr58/software/conda_envs/bactabolize_v1.0.1/lib/python3.9/site-packages/bactabolize/annotate.py", line 50, in run
    match_existing_orfs_updated_annotations(output_fp, assembly_genbank_fp)
  File "/projects/kr58/software/conda_envs/bactabolize_v1.0.1/lib/python3.9/site-packages/bactabolize/annotate.py", line 128, in match_existing_orfs_updated_annotations
    features_matched = discover_overlaps(positions, overlap_min)
  File "/projects/kr58/software/conda_envs/bactabolize_v1.0.1/lib/python3.9/site-packages/bactabolize/annotate.py", line 202, in discover_overlaps
    if (feature_new, feature_existing) in features_matched:
TypeError: unhashable type: 'SeqFeature'
```


Would you be able to test this @helena-bethany ?